### PR TITLE
Restrict Travis builds to the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: php
 
+branches:
+  only:
+    - master
+
 notifications:
   email: false
 


### PR DESCRIPTION
This avoids duplicated builds when using feature branches in the same repo to send pull requests.
This will run builds only for pushes to the master branch or for PRs targetting the master branch.

This can be configured in a more complex way if you have other branches which should be built:
- with a blacklist of branches if you follow a naming convention for your feature branches: https://github.com/Behat/Behat/blob/33f400055af66ef1e24c0ca9404f7d14cf9a7c95/.travis.yml#L5
- with a whitelist of branches if you follow a naming convention for your maintenance branches: https://github.com/FriendsOfSymfony/FOSRestBundle/blob/6bae13c309ea474041ae868f3648f0e2c5452a14/.travis.yml#L9

the last alternative is to avoid using the main repo for feature branches, sending PRs from a personal fork instead (for composer packages, the advantage is that it also avoids adding garbage versions on Packagist btw)
